### PR TITLE
feat(ops): improve docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,13 @@ coverage
 .travis.yml
 scripts
 mlruns-default-experiment
+vitest.config.ts
+docs
+commitlint.config.ts
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+CHANGELOG.md
+compose-before.yml
 
 ## https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
 .yarn/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 0.0.2 (2024-09-20)
 
-
 ### Features
 
-* init project ([b03d004](https://github.com/i-am-bee/bee-observe/commit/b03d004fc9b38ec1412f841485140f2a7258b831))
+- init project ([b03d004](https://github.com/i-am-bee/bee-observe/commit/b03d004fc9b38ec1412f841485140f2a7258b831))

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 > The running Observe instance uses the `Redis`, `MongoDB` and `Mlflow` services. See `./compose-before.yml` for more info on how to run them.
 
 1. create .env.docker file
+
    > Use the `BASE_AUTH` authorization strategy in the production. See `MLFLOW_AUTHORIZATION` env variable.
 
    > Use TLS certificate for MongoDB and Redis. See `MONGODB_CA_CERT` and `REDIS_CA_CERT` env variables.

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -6,7 +6,11 @@ const Configuration: UserConfig = {
     function ignoreDependabot(commit: string) {
       return commit.includes('<support@github.com>') && commit.includes('dependabot');
     }
-  ]
+  ],
+  // Add rules here
+  rules: {
+    'signed-off-by': [2, 'always', 'Signed-off-by']
+  }
 };
 
 export default Configuration;

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -4,31 +4,35 @@
 
 The source directory (`src`) provides numerous modules that one can use.
 
-| Name           | Description                                                                                 |
-| -------------- | ------------------------------------------------------------------------------------------- |
-| **span**       | Base observability unit. Data are accepted in the open-telemetry format.                    |
-| **trace**      | A collection of runs that are related to a single operation.                                |  
-| **mlflow**     | Base UI for tracing. Communication is via the REST API                                      |
-| **migrations** | All database migrations that prepare the necessary data for a valid application run.        |
-| **utils**      | Modules used by other modules within the app.                                               |
+| Name           | Description                                                                          |
+| -------------- | ------------------------------------------------------------------------------------ |
+| **span**       | Base observability unit. Data are accepted in the open-telemetry format.             |
+| **trace**      | A collection of runs that are related to a single operation.                         |
+| **mlflow**     | Base UI for tracing. Communication is via the REST API                               |
+| **migrations** | All database migrations that prepare the necessary data for a valid application run. |
+| **utils**      | Modules used by other modules within the app.                                        |
 
 ### Trace
+
 A trace typically refers to the process of tracking and logging the internal operations, decisions, and interactions that happen during the inference of the model.
 When an LLM processes a prompt, a trace can be used to record the flow of data through the models and such (tools caling, tokens generation, thoughts and plan generation etc..). This is useful for debugging, optimizing, or understanding how the model arrives at a specific output.
 Traces consist of spans that have hierarchical relationships. See the next section for more info.
 
 ### Span
-Each trace consists of multiple spans. 
-A span represents a unit of work done in a particular component or service. 
+
+Each trace consists of multiple spans.
+A span represents a unit of work done in a particular component or service.
 Spans include metadata like start and end time, status, and other contextual data.
 A span can have child spans, representing subprocesses or service calls made by the initial service.
 
 ### Mlflow
-All traces are uploaded/deleted asynchronously to/from the mlflow. We use the BullMQ jobs for this case. 
+
+All traces are uploaded/deleted asynchronously to/from the mlflow. We use the BullMQ jobs for this case.
 You can see all async jobs in the `/mlflow/queue` folder.
 
 ### Migrations
-All database migrations prepare the necessary data for a valid application run. 
+
+All database migrations prepare the necessary data for a valid application run.
 
 ## 📖 Module base structure
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bee-observe",
   "packageManager": "yarn@4.3.1",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "scripts": {
     "build": "rm -rf dist && tsc",
@@ -28,7 +28,6 @@
     "@commitlint/config-conventional": "^19.5.0",
     "@commitlint/types": "^19.5.0",
     "@fastify/type-provider-json-schema-to-ts": "^3.0.0",
-    "@mikro-orm/cli": "6.2.9",
     "@release-it/conventional-changelog": "^8.0.1",
     "@types/dotenv-safe": "^8.1.6",
     "@types/node": "^20.16.5",
@@ -57,6 +56,7 @@
     "@fastify/swagger": "^8.14.0",
     "@fastify/swagger-ui": "^3.0.0",
     "@godaddy/terminus": "^4.12.1",
+    "@mikro-orm/cli": "6.2.9",
     "@mikro-orm/core": "6.2.9",
     "@mikro-orm/migrations-mongodb": "6.2.9",
     "@mikro-orm/mongodb": "6.2.9",

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -49,7 +49,7 @@ const config: Options = {
   driver: MongoDriver,
   // folder-based discovery setup, using common filename suffix
   entities: ['./dist/**/*.document.js'],
-  entitiesTs: ['./src/**/*.document.ts'],
+  entitiesTs: process.env.NODE_ENV !== 'production' ? ['./src/**/*.document.ts'] : [],
 
   /**
    * We are having some ECONNRESET errors on the DIPC cluster. Seems like problem with f5 load balancer.
@@ -81,7 +81,12 @@ const config: Options = {
   driverOptions: {
     ...createMongoTLSConfig()
   },
-  dynamicImportProvider: (id) => import(id)
+  dynamicImportProvider: (id) => {
+    if (process.env.NODE_ENV === 'production') {
+      return import(id.replace(/\.ts$/, '.js')); // Ensure it loads `.js` files in production
+    }
+    return import(id); // Otherwise, load `.ts` files during development
+  }
 };
 
 export default config;


### PR DESCRIPTION
- I cleaned the built docker image and removed the unuseful files and folders. 
- The `@mikro-orm/cli` package is part of the final production image to easily run migrations in docker.
Example in docker compose:
```
  observe_api_migration: 
    image: iambeeagent/bee-observe:0.0.3
    entrypoint: "npx mikro-orm migration:up --config ./dist/mikro-orm.config.js"
    env_file:
      - .env.docker
    environment:
      - NODE_ENV=production
    depends_on:
      - mongo
      - redis
```
- I added a new `signed-off-by` rule to the `commitlint` file that follows [DCO Github rule](https://github.com/i-am-bee/bee-observe/pull/1/checks?check_run_id=31079469838) ([see docs](https://github.com/apps/dco))
- I formated the files via `prettier` and `eslint`