### PR TITLE
add action to publish image on release

### DIFF
--- a/.github/workflows/publish-registy-image.yaml
+++ b/.github/workflows/publish-registy-image.yaml
@@ -1,0 +1,38 @@
+name: build and publish release image
+
+on:
+  # On release events (also when a published release is converted from/to prerelease), push all patterns
+  release:
+    types: [released, prereleased]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ICR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.DOCKER_REGISTRY }}
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Extract version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Build and push bee-observe image
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ vars.DOCKER_REGISTRY }}/i-am-bee/bee-observe:latest
+            ${{ vars.DOCKER_REGISTRY }}/i-am-bee/bee-observe:${{ steps.get_version.outputs.VERSION }}
+          cache-from: type=registry,ref=${{ vars.DOCKER_REGISTRY }}/i-am-bee/bee-observe:buildcache
+          cache-to: type=registry,ref=${{ vars.DOCKER_REGISTRY }}/i-am-bee/bee-observe:buildcache,mode=max


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Adds a GitHub action to publish the container image to IBM Container Registry when a new release is cut.