### PR TITLE
fix: main span nesting in new fw version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@typescript-eslint/eslint-plugin": "^7.13.0",
     "@typescript-eslint/parser": "^7.13.0",
     "@vitest/coverage-v8": "^1.6.0",
-    "bee-agent-framework": "^0.0.45",
+    "bee-agent-framework": "^0.0.52",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",

--- a/src/span/span.document.ts
+++ b/src/span/span.document.ts
@@ -91,9 +91,13 @@ export class Span extends BaseDocument {
     const response = getAttributeValue({ attributes, key: 'response' });
     const statusCode: number = (span.status?.code as any) || 1;
 
+    const traceId = getAttributeValue({ attributes, key: 'traceId' });
+
     return {
       name: span.name,
-      parentId: span.parentSpanId && uint8ArrayToHexString(span.parentSpanId),
+      parentId: !traceId
+        ? span.parentSpanId && uint8ArrayToHexString(span.parentSpanId)
+        : undefined,
       startTime: unixNanoToDate(span.startTimeUnixNano as any),
       endTime: unixNanoToDate(span.endTimeUnixNano as any),
       statusCode: statusCode === 1 ? 'OK' : 'ERROR',
@@ -106,7 +110,7 @@ export class Span extends BaseDocument {
         ctx: ctx && JSON.parse(ctx),
         target: getAttributeValue({ attributes, key: 'target' }),
         name: getAttributeValue({ attributes, key: 'name' }),
-        traceId: getAttributeValue({ attributes, key: 'traceId' }),
+        traceId: traceId,
         prompt: getAttributeValue({ attributes, key: 'prompt' }),
         version: getAttributeValue({ attributes, key: 'version' }),
         response: response && JSON.parse(response),

--- a/src/trace/trace.module.ts
+++ b/src/trace/trace.module.ts
@@ -20,6 +20,7 @@ import { StatusCodes } from 'http-status-codes';
 import { withResultsResponse, withResultResponse, Tags } from '../utils/swagger.js';
 import { ExportTraceServiceRequest__Output } from '../types/generated/opentelemetry/proto/collector/trace/v1/ExportTraceServiceRequest.js';
 import { getModuleLogger } from '../utils/logger-factories.js';
+import { constants } from '../utils/constants.js';
 
 import {
   traceSchema,
@@ -96,8 +97,7 @@ const module: FastifyPluginAsyncJsonSchemaToTs = async (app) => {
         body.resourceSpans.flatMap((resourceSpan) =>
           resourceSpan.scopeSpans.flatMap((scopeSpan) => {
             return {
-              scopeName: scopeSpan.scope?.name,
-              spanNames: scopeSpan.spans.map((span) => span.name)
+              scopeName: scopeSpan.scope?.name
             };
           })
         ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2901,9 +2901,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bee-agent-framework@npm:^0.0.45":
-  version: 0.0.45
-  resolution: "bee-agent-framework@npm:0.0.45"
+"bee-agent-framework@npm:^0.0.52":
+  version: 0.0.52
+  resolution: "bee-agent-framework@npm:0.0.52"
   dependencies:
     "@ai-zen/node-fetch-event-source": "npm:^2.1.4"
     "@connectrpc/connect": "npm:^1.6.1"
@@ -2915,26 +2915,26 @@ __metadata:
     bee-proto: "npm:0.0.2"
     duck-duck-scrape: "npm:^2.2.6"
     fast-xml-parser: "npm:^4.5.0"
-    header-generator: "npm:^2.1.56"
+    header-generator: "npm:^2.1.57"
     joplin-turndown-plugin-gfm: "npm:^1.0.12"
     js-yaml: "npm:^4.1.0"
-    json-schema-to-typescript: "npm:^15.0.2"
-    jsonrepair: "npm:^3.9.0"
-    mathjs: "npm:^13.2.0"
+    json-schema-to-typescript: "npm:^15.0.3"
+    jsonrepair: "npm:^3.11.1"
+    mathjs: "npm:^14.0.0"
     mustache: "npm:^4.2.0"
     object-hash: "npm:^3.0.0"
     p-queue: "npm:^8.0.1"
-    p-throttle: "npm:^6.2.0"
+    p-throttle: "npm:^7.0.0"
     pino: "npm:^9.5.0"
     promise-based-task: "npm:^3.1.1"
-    remeda: "npm:^2.16.0"
+    remeda: "npm:^2.17.4"
     serialize-error: "npm:^11.0.3"
     string-comparison: "npm:^1.3.0"
     string-strip-html: "npm:^13.4.8"
     turndown: "npm:^7.2.0"
     wikipedia: "npm:^2.1.2"
     zod: "npm:^3.23.8"
-    zod-to-json-schema: "npm:^3.23.3"
+    zod-to-json-schema: "npm:^3.23.5"
   peerDependencies:
     "@aws-sdk/client-bedrock-runtime": ^3.687.0
     "@elastic/elasticsearch": ^8.0.0
@@ -2948,7 +2948,7 @@ __metadata:
     "@zilliz/milvus2-sdk-node": ^2.4.9
     google-auth-library: "*"
     groq-sdk: ^0.7.0
-    ollama: ^0.5.8
+    ollama: ^0.5.11
     openai: ^4.67.3
     openai-chat-tokens: ^0.2.8
     sequelize: ^6.37.3
@@ -2985,7 +2985,7 @@ __metadata:
       optional: true
     sequelize:
       optional: true
-  checksum: 10c0/57218dd7d195d1f116e4fc5ead9ab6800edeebbdd05e33f54a28487d141a92fe2ce6cbb8bc46698e33b5f9b77bc2deb2010988f98fa305cf4aa229cd175a8f8f
+  checksum: 10c0/fb4c3f0298be01ad005a9a63de14ab5929029487e7836a30550f6ec32f711a19b80ce7f4fe189de601c3bb3e1225bb0145a6c09efa8c59a05ad76c17683cb5f8
   languageName: node
   linkType: hard
 
@@ -3019,7 +3019,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^7.13.0"
     "@typescript-eslint/parser": "npm:^7.13.0"
     "@vitest/coverage-v8": "npm:^1.6.0"
-    bee-agent-framework: "npm:^0.0.45"
+    bee-agent-framework: "npm:^0.0.52"
     bullmq: "npm:^5.8.2"
     dotenv: "npm:^16.4.5"
     dotenv-safe: "npm:^9.1.0"
@@ -5247,10 +5247,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fraction.js@npm:^4.3.7":
-  version: 4.3.7
-  resolution: "fraction.js@npm:4.3.7"
-  checksum: 10c0/df291391beea9ab4c263487ffd9d17fed162dbb736982dee1379b2a8cc94e4e24e46ed508c6d278aded9080ba51872f1bc5f3a5fd8d7c74e5f105b508ac28711
+"fraction.js@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "fraction.js@npm:5.2.1"
+  checksum: 10c0/4d20062e928d19fa5d1cca031b669785ac3f5817fbd60d4987ebf5c90947a7c602f740218500a5fcbc9bdcf831f729330fa403888561d277ce602fff76e6f015
   languageName: node
   linkType: hard
 
@@ -5346,13 +5346,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"generative-bayesian-network@npm:^2.1.57":
-  version: 2.1.57
-  resolution: "generative-bayesian-network@npm:2.1.57"
+"generative-bayesian-network@npm:^2.1.60":
+  version: 2.1.60
+  resolution: "generative-bayesian-network@npm:2.1.60"
   dependencies:
     adm-zip: "npm:^0.5.9"
     tslib: "npm:^2.4.0"
-  checksum: 10c0/2396e569c3bd1c8823f16a81aeb3039a2a1e5f5c822ecf41827934d53cde1b5a15df51852c9e530da7f851d94c54ed173e3da8d7895eb209f3331a40a054dbeb
+  checksum: 10c0/9fae0a8344f2cb689c4c77a31766d6ad140f7ff6600a10d41494953b7b1ba48e9f06c9be0abfef055183496e4ec4ea62ec064583bde9bc58ce2e105ef70436ac
   languageName: node
   linkType: hard
 
@@ -5727,15 +5727,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"header-generator@npm:^2.1.56":
-  version: 2.1.57
-  resolution: "header-generator@npm:2.1.57"
+"header-generator@npm:^2.1.57":
+  version: 2.1.60
+  resolution: "header-generator@npm:2.1.60"
   dependencies:
     browserslist: "npm:^4.21.1"
-    generative-bayesian-network: "npm:^2.1.57"
+    generative-bayesian-network: "npm:^2.1.60"
     ow: "npm:^0.28.1"
     tslib: "npm:^2.4.0"
-  checksum: 10c0/f884a06930a1d7f21df85b36d4e3275788f7dfa7086f6844d9292252399ff2d410cb383700aad3ccf821d70eb385bab45201388f752990f0d7e058c001a1e6ad
+  checksum: 10c0/1b35131984200e679b98a54511af37c62e1c55a471b7e38f4f8d2dc568eb3f715175e433cc1f89617be4465e51978844f1e22368c98714924c678f9276e7c44e
   languageName: node
   linkType: hard
 
@@ -6611,7 +6611,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema-to-typescript@npm:^15.0.2":
+"json-schema-to-typescript@npm:^15.0.3":
   version: 15.0.3
   resolution: "json-schema-to-typescript@npm:15.0.3"
   dependencies:
@@ -6710,12 +6710,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonrepair@npm:^3.9.0":
-  version: 3.10.0
-  resolution: "jsonrepair@npm:3.10.0"
+"jsonrepair@npm:^3.11.1":
+  version: 3.11.1
+  resolution: "jsonrepair@npm:3.11.1"
   bin:
     jsonrepair: bin/cli.js
-  checksum: 10c0/f46e107b07d9c0def8a0cb3c83c7a0b77fd671d26c1b90ca6cfa1d2480d6ea190bc9c626a1a62b90b0fcdd917a4744899740c0ecd6fac77150754f448de1bb05
+  checksum: 10c0/9bcc739d8eb691d78ebfa04fe565891860cffdcc8970ad37124556e8634d77833dd046b2867eb3758f596754f81932a8f6f0f57a2575a1ea1d6b3eb551076f28
   languageName: node
   linkType: hard
 
@@ -7159,22 +7159,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mathjs@npm:^13.2.0":
-  version: 13.2.3
-  resolution: "mathjs@npm:13.2.3"
+"mathjs@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "mathjs@npm:14.0.0"
   dependencies:
     "@babel/runtime": "npm:^7.25.7"
     complex.js: "npm:^2.2.5"
     decimal.js: "npm:^10.4.3"
     escape-latex: "npm:^1.2.0"
-    fraction.js: "npm:^4.3.7"
+    fraction.js: "npm:^5.2.1"
     javascript-natural-sort: "npm:^0.7.1"
     seedrandom: "npm:^3.0.5"
     tiny-emitter: "npm:^2.1.0"
     typed-function: "npm:^4.2.1"
   bin:
     mathjs: bin/cli.js
-  checksum: 10c0/a8c160931e926a65e59b983f285672ce3797682d703074670e39c11b36a15ceec01e2044de1ef5929227695da21ed2e401ef715c333d564eebff4aaa5c9c48cf
+  checksum: 10c0/2033d50799dcd74b02ef28541f023c63a8aead5e5eb72b135ba70edf1582dda28ee9c622b20747c9d56d8cc986061a898e15f609422ad76fe38555ce6e1f8ed1
   languageName: node
   linkType: hard
 
@@ -7980,10 +7980,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-throttle@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "p-throttle@npm:6.2.0"
-  checksum: 10c0/3be65f66eb21137be78b8d18a5240117312b942e3aa788f838ac4be785ab3c40b64ee34b2c393cd948ec7845c0a00241f446395b98ff4754e718fe54fdee0b00
+"p-throttle@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "p-throttle@npm:7.0.0"
+  checksum: 10c0/7a9ca80826808b3d7f946369fc17a0ba020064c1bda9a5dfa74d2c9713f896576cdc4872bd61091ef2950d6a84072cac672bb1eb88a8b6a0c9e348d030623fc1
   languageName: node
   linkType: hard
 
@@ -8774,7 +8774,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remeda@npm:^2.16.0":
+"remeda@npm:^2.17.4":
   version: 2.17.4
   resolution: "remeda@npm:2.17.4"
   dependencies:
@@ -10891,7 +10891,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-to-json-schema@npm:^3.23.3":
+"zod-to-json-schema@npm:^3.23.5":
   version: 3.23.5
   resolution: "zod-to-json-schema@npm:3.23.5"
   peerDependencies:


### PR DESCRIPTION
- I updated the main span attributes and removed the parentId when the span has the `traceId` in the attributes. 
The trace could have more spans from more scopes and in the scope of framework, the span does not have the parentId, but in the whole trace scope, it could have. 

- I don't throw an error in case the data does not contain the framework events, but I only print the warning message. This is not an error, but an acceptable state. 

- 