### PR TITLE
feat(trace): add retry after header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ PORT=3000
 AUTH_KEY=very-strong-and-long-api-key-with-special-chars
 # 3. Request body limit
 FASTIFY_BODY_LIMIT=10485760 ## default is 10MB
+# 4. value for `Retry-After` header in seconds. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
+# RETRY_AFTER_SECONDS=2 ## the default value is 2
 
 ###########################################
 ################# Redis ###################

--- a/src/trace/trace.service.ts
+++ b/src/trace/trace.service.ts
@@ -70,7 +70,8 @@ export async function getTrace({
     throw new ErrorWithProps(
       `The trace entity with id ${id} does not exist`,
       { code: ErrorWithPropsCodes.NOT_FOUND },
-      StatusCodes.NOT_FOUND
+      StatusCodes.NOT_FOUND,
+      { addRetryAfterHeader: true }
     );
   }
 

--- a/src/trace/trace.test.ts
+++ b/src/trace/trace.test.ts
@@ -39,6 +39,17 @@ describe('trace module', () => {
     expect(res.status).toBe(200);
   });
 
+  it('should use "Retry-After" header and wait until the trace is ready', async () => {
+    let retryAfterTraceId: string | undefined = undefined;
+    await agent.run({ prompt }).middleware((ctx) => (retryAfterTraceId = ctx.emitter.trace?.id));
+    if (retryAfterTraceId) await waitForMlflowTrace({ traceId: retryAfterTraceId });
+
+    const traceResponse = await makeRequest({ route: `v1/traces/${retryAfterTraceId}` });
+
+    // assert it was successful response
+    expect(traceResponse.status).toBe(200);
+  });
+
   it('should return the `bad request` response when the invalid result is sent', async () => {
     const { status, statusText } = await sendCustomProtobuf({
       invalidSpanKey: 4200,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -64,6 +64,7 @@ export const constants = Object.freeze({
   FASTIFY_BODY_LIMIT: parseInt(process.env.FASTIFY_BODY_LIMIT || '10485760'), // default is 10 MB
   REDIS_URL,
   DATA_EXPIRATION_IN_DAYS: parseInt(process.env.DATA_EXPIRATION_IN_DAYS || '7'),
+  RETRY_AFTER_SECONDS: process.env.RETRY_AFTER_SECONDS || 2,
   MLFLOW: Object.freeze({
     API_URL: MLFLOW_API_URL,
     AUTHORIZATION: Object.freeze({


### PR DESCRIPTION
Closes: https://github.com/i-am-bee/bee-observe/issues/16

## Changes
I added the `Retry-After`

## Definition
The HTTP Retry-After [response header](https://developer.mozilla.org/en-US/docs/Glossary/Response_header) indicates how long the user agent should wait before making a follow-up request. There are three main cases this header is used:

- In a [503 Service Unavailable](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503) response, this indicates how long the service is expected to be unavailable.
- In a [429 Too Many Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) response, this indicates how long to wait before making a new request.
- In a redirect response, such as [301 Moved Permanently](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301), this indicates the minimum time that the user agent is asked to wait before issuing the redirected request.

## for /v1/traces/{id} route

> I added this header only for this one route, not for all 404 responses

A 404 Not Found status code signifies that the resource does not exist on the server. Since the issue is not temporary, retrying the request later usually won’t make sense. For clients, this may cause confusion, as Retry-After suggests that the resource might become available after some time, which is contradictory to the meaning of 404.

! Because in the case of `v1/traces/{id}` the resource is temporarily unavailable. !